### PR TITLE
Corrected read time to use proper English

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -14,7 +14,7 @@
                         <div class="author" title="{{ .Params.Author }}"><div class="middot"></div>{{ .Params.author }}</div>
                         {{end}}
                     {{end}}
-                    <div class="reading-time"><div class="middot"></div>{{ if eq 1 .ReadingTime }}{{ .ReadingTime }} minute read{{ else }}{{ .ReadingTime }} minutes read{{ end }}</div>
+                    <div class="reading-time"><div class="middot"></div>{{ .ReadingTime }} minute read</div>
                     <div class="tags">
                         <ul>
                           {{ range .Params.tags }}


### PR DESCRIPTION
See Stack Exchange article below for more information. These nouns are modifying the word read, and thus don't require the plural form.

http://ell.stackexchange.com/questions/14290/shouldnt-five-minute-walk-be-five-minutes-walk-in-this-sentence